### PR TITLE
(Feat) Use google places API to get useful waypoints

### DIFF
--- a/client/app/geoService.js
+++ b/client/app/geoService.js
@@ -9,6 +9,7 @@ angular.module('gservice', [])
       // Initialize the map
       var map, directionsDisplay;
       var directionsService = new google.maps.DirectionsService();
+      // var placesService = new google.maps.places.PlacesService();
 
       var initialize = function () {
         directionsDisplay = new google.maps.DirectionsRenderer();
@@ -47,6 +48,30 @@ angular.module('gservice', [])
         return waypoints;
       };
 
+      //get a single nearby attraction for each waypoint
+      var getNearbyThings = function (waypointArray, distance, type) {
+
+        
+        //build out an array of requests
+        var placeRequests = [];
+        waypointArray.forEach(function(w) {
+          placeRequests.push({
+            location: new google.maps.LatLng(w.lat, w.lng),
+            radius: distance || '500',
+            query: type || 'restaurant'
+          });
+        });
+        //query the google places service
+        for (var i = 0; i < placeRequests.length; i ++) {
+          var placesService = new google.maps.places.PlacesService(null, placeRequests[i].location);
+          placesService.textSearch(placeRequests[i], function(res, status) {
+            if (status == google.maps.places.PlacesServiceStatus.OK) {
+              console.log(results[0]);
+            }
+          });
+        }
+      };
+
       // Refresh, to re-initialize the map.
       // New data could be passed to initialize here
       googleMapService.refresh = function () {
@@ -74,6 +99,7 @@ angular.module('gservice', [])
             //format and send request for the same trip but with waypoints
             var stops = [];
             var waypoints = getWaypoints(result.routes[0].overview_path, numStops);
+            getNearbyThings(waypoints); //testing testing
             waypoints.forEach(function (w) {
               stops.push({
                 location: new google.maps.LatLng(w.lat, w.lng),

--- a/client/app/geoService.js
+++ b/client/app/geoService.js
@@ -1,5 +1,5 @@
 angular.module('gservice', [])
-    .factory('gservice', function($http, $q) {
+    .factory('gservice', function($http, $q, mapFactory) {
 
       var googleMapService = {};
 
@@ -68,7 +68,11 @@ angular.module('gservice', [])
           var placesService = new google.maps.places.PlacesService(document.getElementById('invisible'), placeRequests[i].location);
           placesService.textSearch(placeRequests[i], function(res, status) {
             if (status == google.maps.places.PlacesServiceStatus.OK) {
-              placesToStop.push(res[0].formatted_address);
+              var place = {
+                address: res[0].formatted_address,
+                name: res[0].name
+              }
+              placesToStop.push(place);
               doneSoFar ++;
               if (doneSoFar === placeRequests.length) {
                 deferred.resolve(placesToStop);
@@ -93,6 +97,7 @@ angular.module('gservice', [])
 
       //calculate a route
       googleMapService.calcRoute = function (start, end, numStops) {
+        var deferred = $q.defer();
         var request = {
           origin: start,
           destination: end,
@@ -110,10 +115,10 @@ angular.module('gservice', [])
             var waypoints = getWaypoints(result.routes[0].overview_path, numStops);
             var promise = getNearbyThings(waypoints); //testing testing
             promise.then(function(placePoints) {
-              console.log(placePoints);
+              // mapFactory.listPlaces(placePoints);
               placePoints.forEach(function (w) {
                 stops.push({
-                  location: w,
+                  location: w.address,
                   stopover: true
                 });
               });
@@ -128,11 +133,13 @@ angular.module('gservice', [])
                 if (status === google.maps.DirectionsStatus.OK) {
                   directionsDisplay.setDirections(response);
                   var route = response.routes[0];
+                  deferred.resolve(placePoints);
                 }
               });
             });
           }
         });
+        return deferred.promise;
       };
 
 

--- a/client/app/mapCtrl.js
+++ b/client/app/mapCtrl.js
@@ -2,9 +2,17 @@ angular.module('roadtrippin.maps', ['gservice'])
   .controller('mapController', function($scope, mapFactory, gservice) {
     $scope.route = {};
     $scope.route.numStops = 2;
+    $scope.places = [];
+
     //this is a call to our Google maps API factory for directions
     $scope.getRoute = function() {
-      gservice.calcRoute($scope.route.start, $scope.route.end, $scope.route.numStops);
+      gservice.calcRoute($scope.route.start, $scope.route.end, $scope.route.numStops)
+        .then(function(places) {
+          $scope.places = [];
+          places.forEach(function(place) {
+            $scope.places.push(place);
+          });
+        });
     };
 
     $scope.saveRoute = function () {

--- a/client/index.html
+++ b/client/index.html
@@ -8,7 +8,7 @@
   <link href='https://fonts.googleapis.com/css?family=Fugaz+One|Source+Sans+Pro' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="style.css">
   <!-- External resources -->
-  <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBtSjBdJRohMoWi4nG4odkKwuR9rxoRSBI"></script>
+  <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBtSjBdJRohMoWi4nG4odkKwuR9rxoRSBI&libraries=places"></script>
   <script src="lib/angular/angular.js"></script>
   <!-- Our resources -->
   <script src="app/geoService.js"></script>
@@ -43,11 +43,12 @@
         <div id="info">
           <h3>Your Stops</h3>
           <!-- Need to add actual object name for ng-repeat -->
-          <div class="stop-info" ng-repeat="stopInfo in info"></div>
+          <div class="stop-info" ng-repeat="place in places">{{place.name}}<br/>{{place.address}}</div>
         </div>
         <div id="savedRoutes"></div>
           <div></div>
       </div>
   </div>
+  <div id="invisible"></div>
 </body>
 </html>


### PR DESCRIPTION
Solves #53 
![screen shot 2016-04-08 at 10 27 49 pm](https://cloud.githubusercontent.com/assets/16561075/14401269/92cb42e6-fdd9-11e5-95a0-098d8fca85f3.png)

Google places and google directions do not seem to coexist, so an invisible div `div id="invisible"` is being used to contain the google places map.  This map is used to query for potential stops near each waypoint, and then a single stop is selected and returned.  The route is calculated using these stops, and the name and address of each stop is provided to the controller through a promise.

The number of stops is still hard-coded in, and there are some optional parameters on the waypoint selection that I've left available for later use.  Right now it's defaulting to 'restaurant'.
